### PR TITLE
Area info

### DIFF
--- a/force-app/main/default/classes/appProduct.cls
+++ b/force-app/main/default/classes/appProduct.cls
@@ -1,0 +1,71 @@
+public class appProduct {
+    //get areas that are already defined; 
+ @AuraEnabled(Cacheable=true)
+   public static list<areaWrapper> getAreas(ID recordId){
+       list<areaWrapper> aw = new list<areaWrapper>();
+       for(area__c x:[select id, name from area__c where program__c = :recordId]){
+           aw.add(new areaWrapper(x.name, x.id));
+       }
+      // system.debug(aw);
+       return aw; 
+   }
+    
+    //this is for the pdf wizard to grab the current applications to allow user to select
+    //don't mind areaWrapper name I should have named that class something more generic. areaWrapper will support anything that requires a label value return pair 
+     @AuraEnabled(Cacheable=true)
+   public static list<areaWrapper> getAppPDF(ID recordId){
+       list<areaWrapper> appPDf = new list<areaWrapper>();
+       for(application__c x:[select id, name from application__c where Program_ID__c = :recordId]){
+           appPDF.add(new areaWrapper(x.name, x.id));
+       }
+       system.debug(appPDF);
+       return appPDF; 
+   }
+//need to make it that if the searchKey is blank nothing happens
+//probally better in js    
+  @AuraEnabled(Cacheable=true)
+    public static Product__c[] searchProduct(string searchKey, string cat){
+        searchKey = '%' + searchKey + '%'; 
+        system.debug('cat '+ cat); 
+        list<product__c> searchResult = new list<product__c>();
+        if (cat != null && searchKey == '%%'){
+            return null; 
+        }
+         else if( cat=='ALL'){
+                searchResult = [select id, name, product_name__c, Subcategory__c from product__c where Include_in_Programs__c =True and
+                                (name like :searchKey or product_name__c like :searchKey) limit 10 ]; 
+				system.debug('top select ' +searchResult);                
+        }else{
+            searchResult = [select id, name, product_name__c, Subcategory__c from product__c 
+                            where subcategory__c = :cat and (name like :searchKey or product_name__c like :searchKey) and Include_in_Programs__c =True limit 10]; 
+        				//system.debug('bottom select ' +searchResult);
+        } return searchResult; 
+    } 
+    
+    @AuraEnabled(Cacheable=true)
+    public static list<Application__c> getApps(ID recordId){
+      
+        list<application__c> apps = [Select Name, Id, Date__c, Area_Name__c from Application__c where Program_ID__c =: recordId];
+        
+        return apps;
+            
+    }
+    //get area details when adding to the program 
+    @AuraEnabled
+    public static list<Area__c> areaInfo(string ai){
+        list<area__c> a = [select Area_Sq_Feet__c, name, Pref_U_of_M__c from area__c where id =:ai limit 1 ];
+        //system.debug(a);
+        return a; 
+    }
+    //update application can't use cacheable or cant edita
+    @AuraEnabled
+    public static List<Application_Product__c> appProducts(string app){
+        
+        List<Application_Product__c> prods = [select id, product__c, Product_Name__c,Application__c, Application__r.Name,
+                                              Application__r.Date__c, Unit_Area__c, Rate2__c, area__c, Note__c, Unit_Price__c,
+                                              Total_Price__c, Units_Required__c,Product_Size__c, Application__r.Area__c,
+                                              Application__r.Area__r.Area_Sq_Feet__c, Margin__c, Product_Cost__c from application_product__c where application__c =: app];
+        //system.debug('here are the products ' +prods);
+        return prods; 
+    }
+}

--- a/force-app/main/default/classes/appProduct.cls-meta.xml
+++ b/force-app/main/default/classes/appProduct.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/addProductButton/addProductButton.css
+++ b/force-app/main/default/lwc/addProductButton/addProductButton.css
@@ -1,0 +1,5 @@
+.areaBox{
+    width: 61%; 
+    margin-bottom: 1rem;
+    margin-left: 10px;
+}

--- a/force-app/main/default/lwc/addProductButton/addProductButton.html
+++ b/force-app/main/default/lwc/addProductButton/addProductButton.html
@@ -1,6 +1,22 @@
 <template>
-    <lightning-card  variant="Narrow"  title="App Info" >
-        <lightning-button variant="brand-outline" label="Add Products" 
-        title="Primary action with lighter look" onclick={openModal} class="slds-m-left_x-small"></lightning-button>
+    <lightning-card  variant="Narrow"  title="Area Selected {area}" >
+        <div class='slds-grid'>
+            <div class='slds-col'>
+                <lightning-combobox
+                    name="area"
+                    class='areaBox'
+                    label="Area"
+                    value={area}
+                    placeholder="Select an area to add app too"
+                    options={areaOptions}
+                    onchange={selectArea} ></lightning-combobox>
+            </div>
+        </div>
+        <div class='slds-m-around_small'>
+            <lightning-button variant="brand-outline" label="Add Products" 
+            title="Primary action with lighter look" onclick={openModal} class="slds-m-left_x-small"></lightning-button>
+            <lightning-button variant="success" label="Add Area" 
+            title="newArea" onclick={newArea}></lightning-button>
+        </div>
     </lightning-card>
 </template>

--- a/force-app/main/default/lwc/addProductButton/addProductButton.html
+++ b/force-app/main/default/lwc/addProductButton/addProductButton.html
@@ -1,9 +1,9 @@
 <template>
-    <lightning-card  variant="Narrow"  title="Area Selected {area}" >
+    <lightning-card  variant="Narrow"  title={titleText} >
         <div class='slds-grid'>
             <div class='slds-col'>
                 <lightning-combobox
-                    name="area"
+                    name='box'
                     class='areaBox'
                     label="Area"
                     value={area}
@@ -12,11 +12,21 @@
                     onchange={selectArea} ></lightning-combobox>
             </div>
         </div>
-        <div class='slds-m-around_small'>
-            <lightning-button variant="brand-outline" label="Add Products" 
-            title="Primary action with lighter look" onclick={openModal} class="slds-m-left_x-small"></lightning-button>
-            <lightning-button variant="success" label="Add Area" 
-            title="newArea" onclick={newArea}></lightning-button>
+        <div class='slds-m-around_small slds-grid'>
+            <div class='slds-col'>
+                <lightning-button variant="brand-outline" label="Add Products" 
+                title="Primary action with lighter look" onclick={openModal} class="slds-m-left_x-small"></lightning-button>
+            </div>
+            <div class='slds-col'>
+                <lightning-button variant="success" label="Add Area" 
+                title="newArea" onclick={newArea}></lightning-button>
+            </div>
         </div>
+        <!--New area modal rec-id is how we pass recordId to the child using @api in the child
+        the onnewarea is how we listen for a new custom event from the child and call a function in the 
+        parent-->
+        <c-app-modal
+        rec-id={recordId}
+        onnewarea={addedOption}></c-app-modal>
     </lightning-card>
 </template>

--- a/force-app/main/default/lwc/addProductButton/addProductButton.js
+++ b/force-app/main/default/lwc/addProductButton/addProductButton.js
@@ -1,12 +1,34 @@
-import { LightningElement, wire } from 'lwc';
+import { LightningElement, wire, api } from 'lwc';
+import getAreas from '@salesforce/apex/appProduct.getAreas';
+import {refreshApex} from '@salesforce/apex';
 import { MessageContext, publish} from 'lightning/messageService';
 import Program_Builder from '@salesforce/messageChannel/Program_Builder__c';
 /* https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_salesforce_modules */
 export default class AddProductButton extends LightningElement {
-    
+    @api recordId; 
+    area
     @wire(MessageContext)
         messageContext; 
     
+    @wire(getAreas, {recordId: '$recordId'})
+        areaList
+    //get area options
+    get areaOptions(){
+        //console.log('recordId '+this.recordId);
+        
+        return this.areaList.data; 
+    }
+    
+    selectArea(e){
+        this.area = e.detail.value; 
+        //console.log('area ' + this.area);    
+    }
+
+    newArea(){
+        console.log('clicked');
+        
+    }
+
     openModal(){
         console.log('open modal');
         

--- a/force-app/main/default/lwc/addProductButton/addProductButton.js
+++ b/force-app/main/default/lwc/addProductButton/addProductButton.js
@@ -1,5 +1,6 @@
 import { LightningElement, wire, api } from 'lwc';
 import getAreas from '@salesforce/apex/appProduct.getAreas';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import {refreshApex} from '@salesforce/apex';
 import { MessageContext, publish} from 'lightning/messageService';
 import Program_Builder from '@salesforce/messageChannel/Program_Builder__c';
@@ -7,6 +8,8 @@ import Program_Builder from '@salesforce/messageChannel/Program_Builder__c';
 export default class AddProductButton extends LightningElement {
     @api recordId; 
     area
+    titleText = 'Area Selected ';;
+   selectedLabel
     @wire(MessageContext)
         messageContext; 
     
@@ -18,23 +21,44 @@ export default class AddProductButton extends LightningElement {
         
         return this.areaList.data; 
     }
-    
+    //used to select area plus alert the user in the comp. Will use this to verify an area was set before products added
     selectArea(e){
         this.area = e.detail.value; 
-        //console.log('area ' + this.area);    
+        //areaName = e.target.areaOptions.find(opt => opt.value === e.detail.value).label; 
+        //Wrong I was trying to call my areaOptions not what the system has as target.options
+        this.selectedLabel = e.target.options.find(opt => opt.value === e.detail.value).label;
+        this.titleText += this.selectedLabel        
     }
 
     newArea(){
-        console.log('clicked');
+        //open appModal -- parent to child comm example 
+        this.template.querySelector('c-app-modal').openMe();
         
     }
 
     openModal(){
-        console.log('open modal');
-        
-        const payload = {
-            connector: true
-        }
-        publish(this.messageContext, Program_Builder, payload); 
+        //open productTable if area is selected
+        if(this.area){
+            const payload = {
+                connector: true
+            }
+            publish(this.messageContext, Program_Builder, payload); 
+       }else{
+           this.dispatchEvent(
+               new ShowToastEvent({
+                   title: 'Hold on',
+                   message: 'Please first select an area',
+                   variant: 'error',
+               })
+           )
+           
+       }
+    }
+
+
+    addedOption(){
+        //console.log('dad listening');
+        //listen for the child -> appModal to send parent new area has been added
+        return refreshApex(this.areaList)
     }
 }

--- a/force-app/main/default/lwc/appModal/appModal.html
+++ b/force-app/main/default/lwc/appModal/appModal.html
@@ -1,0 +1,51 @@
+<template>
+    <template if:true={openAppModal}>
+    <div class="newArea">
+        <section role="dialog" tabindex="-1" aria-labelledby="modal-heading-01" aria-modal="true" 
+        aria-describedby="modal-content-id-1" class="slds-modal slds-fade-in-open">
+                    <div class="slds-modal__container">
+                        <header class="slds-modal__header">
+                            <button class="slds-button slds-button_icon slds-modal__close slds-button_icon-inverse" 
+                            title="Close" onclick={closeModal}>
+                                <lightning-icon icon-name="utility:close" size="medium"></lightning-icon>
+                                    <span class="slds-assistive-text">Close</span>
+                                        </button>
+                                    <h2 id="modal-heading-01" 
+                                    class="slds-text-heading_medium slds-hyphenate">Add An Area</h2>
+                                </header>
+                            <div class="slds-modal__content slds-p-around_medium slds-grid" id="modal-content-id-1">
+                                <div class="slds-col slds-size_1-of-2 slds slds-p-horizontal_medium">  
+                                    <lightning-input required type="text" label="Area Name" onchange={newName}></lightning-input>
+                                    <lightning-input type='number' label="Area Sq Feet (M)" onchange={newFeet}></lightning-input>
+                                    <lightning-input type="date" label="Date" onchange={newDate}></lightning-input>
+                                </div>
+                                <div class="slds-col slds-size_1-of-2">
+                                        <lightning-combobox
+                                        name='UofM'
+                                        label='Pref Unit of Measure'
+                                        placeholder='--None--'
+                                        value={prefUM}
+                                        options={setSize}
+                                        onchange={newUM}
+                                        ></lightning-combobox>
+                                    <lightning-input type='number' label="Area Acres" onchange={newAcre}></lightning-input>
+                                    <lightning-combobox
+                                    name='category'
+                                    label='Type'
+                                    placeholder='--None--'
+                                    value={note}
+                                    options={setNotes}
+                                    onchange={newType}
+                                   ></lightning-combobox>
+                                </div>
+                    </div>
+                <footer class="slds-modal__footer">
+            <lightning-button label="Cancel" variant="neutral" onclick={closeModal}></lightning-button>&nbsp;&nbsp;&nbsp;&nbsp;
+        <lightning-button label="Save" variant="brand" onclick={saveArea}></lightning-button>
+    </footer>
+</div>
+</section>
+</div>
+<div class='slds-backdrop slds-backdrop_open'></div>     
+</template>
+</template>

--- a/force-app/main/default/lwc/appModal/appModal.js
+++ b/force-app/main/default/lwc/appModal/appModal.js
@@ -1,0 +1,121 @@
+import { LightningElement, api } from 'lwc';
+import { createRecord } from 'lightning/uiRecordApi';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import AREA_OBJECT from '@salesforce/schema/Area__c'; 
+import NAME_FIELD from '@salesforce/schema/Area__c.Name';
+import DATE_FIELD from '@salesforce/schema/Area__c.Date__c';
+import SQF_FIELD from '@salesforce/schema/Area__c.Area_Sq_Feet__c';
+import ACRE_FIELD from '@salesforce/schema/Area__c.Area_Acres__c';
+import TYPE_FIELD from '@salesforce/schema/Area__c.Type__c';  
+import PROGRAM_FIELD from '@salesforce/schema/Area__c.Program__c';  
+import PREFUOFM from '@salesforce/schema/Area__c.Pref_U_of_M__c'; 
+
+export default class AppModal extends LightningElement {
+    openAppModal = false; 
+    note;
+    areaName;
+    areaDate
+    areaAcres
+    areaType;
+    areaId;
+    proId;
+    preUm;
+    recordId; 
+    @api recId; 
+//open close modal
+    @api 
+    openMe(){
+        this.openAppModal = true; 
+    }
+    closeModal(){
+        this.openAppModal = false; 
+    }
+
+    //get api values from object settings
+    get setNotes(){
+        return [
+            {label:'Athletic Field' , value: 'Athletic Field'},
+            {label:'Greens', value: 'Greens'},
+            {label:'Tees', value: 'Tees'},
+            {label:'Fairways' , value: 'Fairways'},
+            {label:'Fairways/Tees' , value: 'Fairways/Tees'},
+            {label:'Rough' , value: 'Rough'},
+            {label:'Other' , value: 'Other'} 
+        ]
+    }   
+    get setSize(){
+        return [
+            {label:'Acre', value: 'Acre'},
+            {label: 'M', value:'M'}
+        ]
+    }
+    //input field actions
+    newName(e){
+        this.areaName = e.detail.value;
+        this.areaId = undefined; 
+        
+    }
+    newDate(e){
+        this.areaDate = e.detail.value;
+    }
+    newFeet(e){
+        this.feet = e.detail.value;
+        this.areaAcres = this.feet/43.56
+        
+    }
+    newAcre(e){
+        this.areaAcres = e.detail.value; 
+        this.feet = this.areaAcres * 43.56; 
+                    
+    }
+    newType(e){
+        this.note = e.detail.value; 
+        //console.log(this.note, ' this note');
+        
+    }
+    newUM(e){
+        this.prefUM = e.detail.value; 
+        console.log(this.recId);
+         
+    }
+    saveArea(){
+        const fields ={}; 
+        fields[NAME_FIELD.fieldApiName] = this.areaName;
+        fields[DATE_FIELD.fieldApiName] = this.areaDate;
+        fields[SQF_FIELD.fieldApiName] = this.feet;
+        fields[ACRE_FIELD.fieldApiName] = this.areaAcres;
+        fields[TYPE_FIELD.fieldApiName] = this.note;
+        fields[PROGRAM_FIELD.fieldApiName] = this.recId;
+        fields[PREFUOFM.fieldApiName]= this.prefUM;
+        console.log(fields);
+        
+        const recordInput = {apiName: AREA_OBJECT.objectApiName, fields};
+        //create record
+        createRecord(recordInput)
+        .then(area => {
+            this.areaId = area.id; 
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Success',
+                    message: 'Area created',
+                    variant: 'success',
+                }),
+            );
+        })
+        .then(this.openAppModal = false)
+        .then(()=>{
+            //console.log('alex is talking');
+            //send a new event to the parent -> addProductButton
+            this.dispatchEvent(new CustomEvent('newarea')); 
+        }).catch(error => {
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Error creating record',
+                    message: error.body.message,
+                    variant: 'error',
+                }),
+                console.log(JSON.stringify(error))
+            );
+        });
+}
+}

--- a/force-app/main/default/lwc/appModal/appModal.js-meta.xml
+++ b/force-app/main/default/lwc/appModal/appModal.js-meta.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordPage</target>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <!--<target>lightning__Tab</target>-->
+        <!--<target>lightning__Inbox</target>-->
+        <!--<target>lightning__UtilityBar</target>-->
+        <!--<target>lightning__FlowScreen</target>-->
+        <!--<target>lightningSnapin__ChatMessage</target>-->
+        <!--<target>lightningSnapin__Minimized</target>-->
+        <!--<target>lightningSnapin__PreChat</target>-->
+        <!--<target>lightningSnapin__ChatHeader</target>-->
+        <!--<target>lightningCommunity__Page</target>-->
+        <!--<target>lightningCommunity__Default</target>-->
+    </targets>
+</LightningComponentBundle>


### PR DESCRIPTION
Only need to clean up UI showing current name otherwise selecting an area or creating a new one on the child is complete. It will also update the parent with new results. Will throw an toast error if user tries to add products without first selecting an area. Per my requirement I will not delete this branch because the area section is acceptable at this point. If I need to ref or fall back I want the branch. 